### PR TITLE
New diffractometer setup

### DIFF
--- a/instrument/devices/__init__.py
+++ b/instrument/devices/__init__.py
@@ -5,3 +5,4 @@ local, custom Device definitions
 from .simulated_fourc_vertical import fourc
 from .simulated_new_diffractometer import diffract
 from .simulated_detector import simdet
+from .nanopositioner import nanopositioner

--- a/instrument/devices/__init__.py
+++ b/instrument/devices/__init__.py
@@ -2,5 +2,4 @@
 local, custom Device definitions
 """
 
-from .simulated_fourc import fourc
-
+from .simulated_fourc_vertical import fourc

--- a/instrument/devices/__init__.py
+++ b/instrument/devices/__init__.py
@@ -3,3 +3,4 @@ local, custom Device definitions
 """
 
 from .simulated_fourc_vertical import fourc
+from .simulated_new_diffractometer import diffract

--- a/instrument/devices/__init__.py
+++ b/instrument/devices/__init__.py
@@ -4,3 +4,4 @@ local, custom Device definitions
 
 from .simulated_fourc_vertical import fourc
 from .simulated_new_diffractometer import diffract
+from .simulated_detector import simdet

--- a/instrument/devices/nanopositioner.py
+++ b/instrument/devices/nanopositioner.py
@@ -1,0 +1,20 @@
+'''
+Nanopositioner motors
+'''
+ 
+__all__ = ['nanopositioner']
+
+from ophyd import Component, MotorBundle, EpicsMotor
+from ..framework import sd
+from ..session_logs import logger
+logger.info(__file__)
+
+
+class NanoPositioner(MotorBundle):
+    nanoy = Component(EpicsMotor, 'm1', labels=('motor', 'nanopositioner'))
+    nanox = Component(EpicsMotor, 'm2', labels=('motor', 'nanopositioner'))
+    nanoz = Component(EpicsMotor, 'm3', labels=('motor', 'nanopositioner'))
+
+
+nanopositioner = NanoPositioner('4idIF:', name='nanopositioner')
+sd.baseline.append(nanopositioner)

--- a/instrument/devices/simulated_detector.py
+++ b/instrument/devices/simulated_detector.py
@@ -3,6 +3,7 @@ __all__ = ['simdet']
 
 from ophyd.signal import SignalRO
 from numpy.random import default_rng
+from time import sleep
 from ..framework import sd
 from ..session_logs import logger
 logger.info(__file__)
@@ -12,9 +13,22 @@ class RandomDet(SignalRO):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._gen = default_rng()
+        self._count_time = 1
 
     def get(self, **kwargs):
+        sleep(self._count_time)
         return self._gen.random()
+
+    @property
+    def count_time(self):
+        return self._count_time
+
+    @count_time.setter
+    def count_time(self, value):
+        if isinstance(value, (int, float)):
+            self._count_time = value
+        else:
+            raise ValueError("Count time must be a number.")
 
 
 simdet = RandomDet(name="simdet")

--- a/instrument/devices/simulated_detector.py
+++ b/instrument/devices/simulated_detector.py
@@ -1,0 +1,20 @@
+
+__all__ = ['simdet']
+
+from ophyd.signal import SignalRO
+from numpy.random import default_rng
+from ..framework import sd
+from ..session_logs import logger
+logger.info(__file__)
+
+
+class RandomDet(SignalRO):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._gen = default_rng()
+
+    def get(self, **kwargs):
+        return self._gen.random()
+
+
+simdet = RandomDet(name="simdet")

--- a/instrument/devices/simulated_fourc_vertical.py
+++ b/instrument/devices/simulated_fourc_vertical.py
@@ -4,8 +4,7 @@ Simulated fourc
 
 __all__ = ['fourc']
 
-from ophyd import Component, PseudoSingle, Kind, Signal
-from ophyd.sim import SynAxis
+from ophyd import Component, PseudoSingle, Kind, Signal, EpicsMotor
 from ..framework import sd
 import gi
 gi.require_version('Hkl', '5.0')
@@ -28,10 +27,10 @@ class FourCircleDiffractometer(E4CV):
     k = Component(PseudoSingle, '', labels=("hkl", "fourc"))
     l = Component(PseudoSingle, '', labels=("hkl", "fourc"))
 
-    omega = Component(SynAxis, name="omega", labels=("motor", "fourc"))
-    chi = Component(SynAxis, name="chi", labels=("motor", "fourc"))
-    phi = Component(SynAxis, name="phi", labels=("motor", "fourc"))
-    tth = Component(SynAxis, name="tth", labels=("motor", "fourc"))
+    omega = Component(EpicsMotor, "m1", labels=("motor", "fourc"))
+    chi = Component(EpicsMotor, "m2", labels=("motor", "fourc"))
+    phi = Component(EpicsMotor, "m3", labels=("motor", "fourc"))
+    tth = Component(EpicsMotor, "m4", labels=("motor", "fourc"))
 
     # Explicitly selects the real motors
     # _real = ['theta', 'chi', 'phi', 'tth']
@@ -53,10 +52,7 @@ class FourCircleDiffractometer(E4CV):
         return {'fields': fields}
 
 
-fourc = FourCircleDiffractometer("", name='fourc')
-fourc.omega.setpoint.put(1)
-fourc.chi.setpoint.put(0)
-fourc.phi.setpoint.put(0)
-fourc.tth.setpoint.put(2)
+fourc = FourCircleDiffractometer("4idsoftmotors:", name='fourc')
 select_diffractometer(fourc)
 sd.baseline.append(fourc)
+

--- a/instrument/devices/simulated_fourc_vertical.py
+++ b/instrument/devices/simulated_fourc_vertical.py
@@ -2,13 +2,10 @@
 Simulated fourc
 """
 
-from ophyd import Component, Device
-from ophyd.sim import SynAxis
-
-
 __all__ = ['fourc']
 
-from ophyd import (Component, PseudoSingle, Kind, Signal)
+from ophyd import Component, PseudoSingle, Kind, Signal
+from ophyd.sim import SynAxis
 from ..framework import sd
 import gi
 gi.require_version('Hkl', '5.0')

--- a/instrument/devices/simulated_fourc_vertical.py
+++ b/instrument/devices/simulated_fourc_vertical.py
@@ -63,4 +63,3 @@ fourc.phi.setpoint.put(0)
 fourc.tth.setpoint.put(2)
 select_diffractometer(fourc)
 sd.baseline.append(fourc)
-

--- a/instrument/devices/simulated_new_diffractometer.py
+++ b/instrument/devices/simulated_new_diffractometer.py
@@ -1,0 +1,66 @@
+"""
+Simulated diffract
+"""
+
+__all__ = ['diffract']
+
+from ophyd import Component, PseudoSingle, Kind, Signal
+from ophyd.sim import SynAxis
+from ..framework import sd
+import gi
+gi.require_version('Hkl', '5.0')
+# MUST come before `import hkl`
+from hkl.geometries import E4CV
+from hkl.user import select_diffractometer
+from ..session_logs import logger
+logger.info(__file__)
+
+
+class FourCircleDiffractometer(E4CV):
+    """
+    E4CV: huber diffractometer in 4-circle vertical geometry with energy.
+
+    4-ID-D setup.
+    """
+
+    # HKL and 4C motors
+    h = Component(PseudoSingle, '', labels=("hkl", "diffract"))
+    k = Component(PseudoSingle, '', labels=("hkl", "diffract"))
+    l = Component(PseudoSingle, '', labels=("hkl", "diffract"))
+
+    mu = Component(SynAxis, name="mu", labels=("motor", "diffract"))
+    omega = Component(SynAxis, name="omega", labels=("motor", "diffract"))
+    chi = Component(SynAxis, name="chi", labels=("motor", "diffract"))
+    phi = Component(SynAxis, name="phi", labels=("motor", "diffract"))
+    delta = Component(SynAxis, name="delta", labels=("motor", "diffract"))
+    gamma = Component(SynAxis, name="gamma", labels=("motor", "diffract"))
+
+    # Explicitly selects the real motors
+    # _real = ['theta', 'chi', 'phi', 'tth']
+    _real = "mu omega chi phi delta gamma".split()
+
+    # Energy
+    energy = Component(Signal, value=8)
+    energy_update_calc_flag = Component(Signal, value=1)
+    energy_offset = Component(Signal, value=0)
+
+    # TODO: This is needed to prevent busy plotting.
+    @property
+    def hints_test(self):
+        fields = []
+        for _, component in self._get_components_of_kind(Kind.hinted):
+            if (~Kind.normal & Kind.hinted) & component.kind:
+                c_hints = component.hints
+                fields.extend(c_hints.get('fields', []))
+        return {'fields': fields}
+
+
+diffract = FourCircleDiffractometer("", name='diffract')
+diffract.mu.setpoint.put(0)
+diffract.omega.setpoint.put(1)
+diffract.chi.setpoint.put(0)
+diffract.phi.setpoint.put(0)
+diffract.delta.setpoint.put(2)
+diffract.gamma.setpoint.put(2)
+select_diffractometer(diffract)
+sd.baseline.append(diffract)

--- a/instrument/devices/simulated_new_diffractometer.py
+++ b/instrument/devices/simulated_new_diffractometer.py
@@ -4,8 +4,7 @@ Simulated diffract
 
 __all__ = ['diffract']
 
-from ophyd import Component, PseudoSingle, Kind, Signal
-from ophyd.sim import SynAxis
+from ophyd import Component, PseudoSingle, Kind, Signal, EpicsMotor
 from ..framework import sd
 import gi
 gi.require_version('Hkl', '5.0')
@@ -28,12 +27,12 @@ class FourCircleDiffractometer(Petra3_p09_eh2):
     k = Component(PseudoSingle, '', labels=("hkl", "diffract"))
     l = Component(PseudoSingle, '', labels=("hkl", "diffract"))
 
-    mu = Component(SynAxis, name="mu", labels=("motor", "diffract"))
-    omega = Component(SynAxis, name="omega", labels=("motor", "diffract"))
-    chi = Component(SynAxis, name="chi", labels=("motor", "diffract"))
-    phi = Component(SynAxis, name="phi", labels=("motor", "diffract"))
-    delta = Component(SynAxis, name="delta", labels=("motor", "diffract"))
-    gamma = Component(SynAxis, name="gamma", labels=("motor", "diffract"))
+    mu = Component(EpicsMotor, "m9", labels=("motor", "diffract"))
+    omega = Component(EpicsMotor, "m10", labels=("motor", "diffract"))
+    chi = Component(EpicsMotor, "m11", labels=("motor", "diffract"))
+    phi = Component(EpicsMotor, "m12", labels=("motor", "diffract"))
+    delta = Component(EpicsMotor, "m13", labels=("motor", "diffract"))
+    gamma = Component(EpicsMotor, "m14", labels=("motor", "diffract"))
 
     # Explicitly selects the real motors
     # _real = ['theta', 'chi', 'phi', 'tth']
@@ -55,12 +54,7 @@ class FourCircleDiffractometer(Petra3_p09_eh2):
         return {'fields': fields}
 
 
-diffract = FourCircleDiffractometer("", name='diffract')
-diffract.mu.setpoint.put(0)
-diffract.omega.setpoint.put(1)
-diffract.chi.setpoint.put(0)
-diffract.phi.setpoint.put(0)
-diffract.delta.setpoint.put(2)
-diffract.gamma.setpoint.put(2)
+diffract = FourCircleDiffractometer("4idsoftmotors:", name='diffract')
 select_diffractometer(diffract)
 sd.baseline.append(diffract)
+

--- a/instrument/devices/simulated_new_diffractometer.py
+++ b/instrument/devices/simulated_new_diffractometer.py
@@ -10,13 +10,13 @@ from ..framework import sd
 import gi
 gi.require_version('Hkl', '5.0')
 # MUST come before `import hkl`
-from hkl.geometries import E4CV
+from hkl.geometries import Petra3_p09_eh2
 from hkl.user import select_diffractometer
 from ..session_logs import logger
 logger.info(__file__)
 
 
-class FourCircleDiffractometer(E4CV):
+class FourCircleDiffractometer(Petra3_p09_eh2):
     """
     E4CV: huber diffractometer in 4-circle vertical geometry with energy.
 


### PR DESCRIPTION
New devices:
- Simulated diffractometer (diffract device) of our new instrument. Using the Petra geometry, see hkl [manual](https://people.debian.org/~picca/hkl/hkl.html#org7791cee) for details on motors and modes.
- Simulated detector (simdet device, generates random [0, 1) numbers) with a count time.

To test this, first make sure that you are in the correct branch (new-diffractometer), start bluesky using `blueskyStarter.sh`, then:
```python
In [6]: simdet.count_time = 0.1

In [7]: RE(bp.rel_scan([simdet], diffract.mu, -2, 2, 10))


Transient Scan ID: 68     Time: 2023-09-12 15:17:03
Persistent Unique Scan ID: '3c2bf61f-11df-420d-83a7-6670417dc8f9'
New stream: 'baseline'
New stream: 'primary'
+-----------+------------+-------------+------------+
|   seq_num |       time | diffract_mu |     simdet |
+-----------+------------+-------------+------------+
|         1 | 15:17:04.1 |      -2.000 |      0.358 |
|         2 | 15:17:04.2 |      -1.556 |      0.348 |
|         3 | 15:17:04.4 |      -1.111 |      0.721 |
|         4 | 15:17:04.5 |      -0.667 |      0.938 |
|         5 | 15:17:04.6 |      -0.222 |      0.288 |
|         6 | 15:17:04.8 |       0.222 |      0.863 |
|         7 | 15:17:04.9 |       0.667 |      0.065 |
|         8 | 15:17:05.0 |       1.111 |      0.185 |
|         9 | 15:17:05.1 |       1.556 |      0.753 |
|        10 | 15:17:05.3 |       2.000 |      0.170 |
+-----------+------------+-------------+------------+
generator rel_scan ['3c2bf61f'] (scan num: 68)
Out[7]: ('3c2bf61f-11df-420d-83a7-6670417dc8f9',)
```