### PR TITLE
Eiger1m setup

### DIFF
--- a/blueskyStarter.sh
+++ b/blueskyStarter.sh
@@ -4,7 +4,7 @@
 
 # Get the Python environment name.
 # define fallback if BLUESKY_CONDA_ENV is not found
-DEFAULT_ENV=bluesky_2023_3
+DEFAULT_ENV=bluesky_2024_2
 export ENV_NAME="${BLUESKY_CONDA_ENV:-${DEFAULT_ENV}}"
 export IPYTHON_PROFILE=bluesky
 export IPYTHONDIR="${HOME}/.ipython"

--- a/instrument/devices/4idd/ad_eiger1M-bkp.py
+++ b/instrument/devices/4idd/ad_eiger1M-bkp.py
@@ -1,22 +1,26 @@
 """ Eiger 1M setup """
 
-from ophyd import ADComponent, Staged
+from ophyd import ADComponent, EpicsSignal, Staged, Signal
 from ophyd.status import wait as status_wait, SubscriptionStatus
-from ophyd.areadetector import DetectorBase
+from ophyd.areadetector import DetectorBase, EigerDetectorCam
+from ophyd.areadetector.plugins import(
+    PluginBase_V34,
+    ImagePlugin_V34,
+    PvaPlugin_V34,
+    ROIPlugin_V34,
+    StatsPlugin_V34,
+    CodecPlugin_V34,
+    HDF5Plugin_V34
+)
+from ophyd.areadetector.filestore_mixins import FileStoreBase
 from ophyd.areadetector.trigger_mixins import TriggerBase, ADTriggerStatus
-from apstools.devices import AD_plugin_primed, AD_prime_plugin2
+from apstools.devices import AD_plugin_primed, AD_prime_plugin2, CamMixin_V34
 from apstools.utils import run_in_thread
 from pathlib import PurePath
 from time import time as ttime, sleep
-from .ad_mixins import (
-    EigerDetectorCam,
-    CodecPlugin,
-    ImagePlugin,
-    ROIPlugin,
-    StatsPlugin,
-    PvaPlugin,
-    EigerHDF5Plugin
-)
+from os.path import isfile
+from datetime import datetime
+from itertools import count
 from .. import iconfig  # noqa
 from ..session_logs import logger
 logger.info(__file__)
@@ -26,6 +30,186 @@ __all__ = ["load_eiger1m"]
 BLUESKY_FILES_ROOT = PurePath(iconfig["AREA_DETECTOR"]["BLUESKY_FILES_ROOT"])
 IOC_FILES_ROOT = PurePath(iconfig["AREA_DETECTOR"]["EIGER_1M"]["IOC_FILES_ROOT"])
 IMAGE_DIR = iconfig["AREA_DETECTOR"].get("IMAGE_DIR", "%Y/%m/%d/")
+
+
+class PluginMixin(PluginBase_V34):
+    """Remove property attribute found in AD IOCs now."""
+
+    _asyn_pipeline_configuration_names = None
+
+
+class ImagePlugin(PluginMixin, ImagePlugin_V34):
+    """Remove property attribute found in AD IOCs now."""
+
+
+class PvaPlugin(PluginMixin, PvaPlugin_V34):
+    """Remove property attribute found in AD IOCs now."""
+
+
+class ROIPlugin(PluginMixin, ROIPlugin_V34):
+    """Remove property attribute found in AD IOCs now."""
+
+
+class StatsPlugin(PluginMixin, StatsPlugin_V34):
+    """Remove property attribute found in AD IOCs now."""
+
+
+class EigerDetectorCam_V34(CamMixin_V34, EigerDetectorCam):
+    """Revise EigerDetectorCam for ADCore revisions."""
+
+    initialize = ADComponent(EpicsSignal, "Initialize", kind="config")
+
+    # These components not found on Eiger 4M at 8-ID-I
+    file_number_sync = None
+    file_number_write = None
+    fw_clear = None
+    link_0 = None
+    link_1 = None
+    link_2 = None
+    link_3 = None
+    dcu_buff_free = None
+    offset = None
+
+
+class FileStorePluginBaseEpicsName(FileStoreBase):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if hasattr(self, "create_directory"):
+            self.stage_sigs.update({"create_directory": -3})
+        self.stage_sigs.update(
+            [
+                ("auto_increment", "Yes"),
+                ("array_counter", 0),
+                ("auto_save", "Yes"),
+                ("num_capture", 0),
+            ]
+        )
+        self._fn = None
+        self._fp = None
+
+    # This is the part to change if a different file scheme is chosen.
+    def make_write_read_paths(self):
+        # Folders - this allows for using dates for folders.
+        formatter = datetime.now().strftime
+        write_path = formatter(self.write_path_template)
+        read_path = formatter(self.read_path_template)
+
+        # File name -- assumes some sort of %s%s_5.5%d.h5 format
+        file_read = self.file_template.get() % (
+            read_path,
+            self.file_name.get(),
+            int(self.file_number.get())
+        )
+
+        file_write = self.file_template.get() % (
+            write_path + "/",
+            self.file_name.get(),
+            int(self.file_number.get())
+        )
+
+        return write_path, file_write, read_path, file_read
+
+    def stage(self):
+
+        # Only save images if the enable is on...
+        if self.enable.get() in (True, 1, "on", "Enable"):
+
+            if self.file_write_mode.get(as_string=True) != "Single":
+                self.capture.set(0).wait()
+            
+            write_path, file_write, read_path, file_read = self.make_write_read_paths()
+
+            if isfile(file_write):
+                raise OSError(
+                    f"{file_write} already exists! Cannot overwrite it, so please "
+                    "change the file name."
+                )
+
+            self.file_path.set(write_path).wait()
+            super().stage()
+
+            self._fn = file_read
+            self._fp = read_path
+            if not self.file_path_exists.get():
+                raise IOError(
+                    "Path %s does not exist on IOC." "" % self.file_path.get()
+                )
+
+
+class FileStoreHDF5IterativeWriteEpicsName(FileStorePluginBaseEpicsName):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.filestore_spec = "AD_HDF5"  # spec name stored in resource doc
+        self.stage_sigs.update(
+            [
+                ("file_template", "%s%s_%6.6d.h5"),
+                ("file_write_mode", "Stream"),
+                ("capture", 1),
+            ]
+        )
+        self._point_counter = None
+
+    def get_frames_per_point(self):
+        num_capture = self.num_capture.get()
+        # If num_capture is 0, then the plugin will capture however many frames
+        # it is sent. We can get how frames it will be sent (unless
+        # interrupted) by consulting num_images on the detector's camera.
+        if num_capture == 0:
+            return self.parent.cam.num_images.get()
+        # Otherwise, a nonzero num_capture will cut off capturing at the
+        # specified number.
+        return num_capture
+
+    def stage(self):
+        super().stage()
+        res_kwargs = {"frame_per_point": self.get_frames_per_point()}
+        self._generate_resource(res_kwargs)
+        self._point_counter = count()
+
+    def unstage(self):
+        self._point_counter = None
+        super().unstage()
+
+    def generate_datum(self, key, timestamp, datum_kwargs):
+        i = next(self._point_counter)
+        datum_kwargs = datum_kwargs or {}
+        datum_kwargs.update({"point_number": i})
+        return super().generate_datum(key, timestamp, datum_kwargs)
+
+
+class HDF5Plugin(PluginMixin, HDF5Plugin_V34):
+    pass
+
+
+class EigerHDF5Plugin(HDF5Plugin, FileStoreHDF5IterativeWriteEpicsName):
+
+    """
+    Using the filename from EPICS.
+    """
+
+    autosave = ADComponent(Signal, value="off", kind="config")
+
+    def __init__(self, *args, write_path_template="", **kwargs):
+        # self.filestore_spec = "AD_EIGER_APSPolar"
+        super().__init__(*args, write_path_template=write_path_template, **kwargs)
+        self.enable.subscribe(self._setup_kind)
+
+    def _setup_kind(self, value, **kwargs):
+        if value in (True, 1, "on", "Enable"):
+            self.kind = "normal"
+        else:
+            self.kind = "omitted"
+
+    def stage(self):
+        if self.autosave.get() in (True, 1, "on", "Enable"):
+            self.parent.save_images_on()
+        super().stage()
+
+    def unstage(self):
+        if self.autosave.get() in (True, 1, "on", "Enable"):
+            self.parent.save_images_off()
+        super().unstage()
 
 
 class TriggerTime(TriggerBase):
@@ -110,8 +294,8 @@ class Eiger1MDetector(TriggerTime, DetectorBase):
     _default_configuration_attrs = ('roi1', 'codec1', 'image', 'pva')
     _default_read_attrs = ('cam', 'hdf1', 'stats1')
     
-    cam = ADComponent(EigerDetectorCam, "cam1:")
-    codec1 = ADComponent(CodecPlugin, "Codec1:")
+    cam = ADComponent(EigerDetectorCam_V34, "cam1:")
+    codec1 = ADComponent(CodecPlugin_V34, "Codec1:")
     image = ADComponent(ImagePlugin, "image1:")
     roi1 = ADComponent(ROIPlugin, "ROI1:")
     stats1 = ADComponent(StatsPlugin, "Stats1:", kind="normal")

--- a/instrument/devices/__init__.py
+++ b/instrument/devices/__init__.py
@@ -10,3 +10,4 @@ from .simulated_detector import simdet
 from .nanopositioner import diff_nano
 from .interferometers_4IDG import interferometer
 from .magnet_nanopositioner import magnet_nano
+from .ad_eiger1M import load_eiger1m

--- a/instrument/devices/ad_eiger1M.py
+++ b/instrument/devices/ad_eiger1M.py
@@ -1,0 +1,155 @@
+""" Eiger 1M setup """
+
+from ophyd import ADComponent, EpicsSignal, Kind
+from ophyd.status import Status
+from ophyd.areadetector import DetectorBase, EigerDetectorCam, SingleTrigger
+from ophyd.areadetector.plugins import(
+    PluginBase_V34,
+    ImagePlugin_V34,
+    PvaPlugin_V34,
+    ROIPlugin_V34,
+    StatsPlugin_V34,
+    CodecPlugin_V34
+)
+from apstools.devices import (
+    AD_EpicsFileNameHDF5Plugin, AD_plugin_primed, AD_prime_plugin2, CamMixin_V34
+)
+from pathlib import PurePath
+from time import time
+from .. import iconfig  # noqa
+from ..session_logs import logger
+logger.info(__file__)
+
+__all__ = ["load_eiger1m"]
+
+BLUESKY_FILES_ROOT = PurePath(iconfig["AREA_DETECTOR"]["BLUESKY_FILES_ROOT"])
+IOC_FILES_ROOT = PurePath(iconfig["AREA_DETECTOR"]["EIGER_1M"]["IOC_FILES_ROOT"])
+IMAGE_DIR = iconfig["AREA_DETECTOR"].get("IMAGE_DIR", "%Y/%m/%d/")
+
+
+class PluginMixin(PluginBase_V34):
+    """Remove property attribute found in AD IOCs now."""
+
+    _asyn_pipeline_configuration_names = None
+
+
+class ImagePlugin(PluginMixin, ImagePlugin_V34):
+    """Remove property attribute found in AD IOCs now."""
+
+
+class PvaPlugin(PluginMixin, PvaPlugin_V34):
+    """Remove property attribute found in AD IOCs now."""
+
+
+class ROIPlugin(PluginMixin, ROIPlugin_V34):
+    """Remove property attribute found in AD IOCs now."""
+
+
+class StatsPlugin(PluginMixin, StatsPlugin_V34):
+    """Remove property attribute found in AD IOCs now."""
+
+
+class EigerDetectorCam_V34(CamMixin_V34, EigerDetectorCam):
+    """Revise EigerDetectorCam for ADCore revisions."""
+
+    initialize = ADComponent(EpicsSignal, "Initialize", kind="config")
+
+    # These components not found on Eiger 4M at 8-ID-I
+    file_number_sync = None
+    file_number_write = None
+    fw_clear = None
+    link_0 = None
+    link_1 = None
+    link_2 = None
+    link_3 = None
+    dcu_buff_free = None
+    offset = None
+
+
+class XpcsAD_EpicsFileNameHDF5Plugin(PluginMixin, AD_EpicsFileNameHDF5Plugin):
+    """Remove property attribute not found in AD IOCs now."""
+
+    @property
+    def _plugin_enabled(self):
+        return self.stage_sigs.get("enable") in (1, "Enable")
+
+    def generate_datum(self, *args, **kwargs):
+        if self._plugin_enabled:
+            super().generate_datum(*args, **kwargs)
+
+    def read(self):
+        if self._plugin_enabled:
+            readings = super().read()
+        else:
+            readings = {}
+        return readings
+
+    def stage(self):
+        if self._plugin_enabled:
+            staged_objects = super().stage()
+        else:
+            staged_objects = []
+        return staged_objects
+
+    def trigger(self):
+        if self._plugin_enabled:
+            trigger_status = super().trigger()
+        else:
+            trigger_status = Status(self)
+            trigger_status.set_finished()
+        return trigger_status
+
+
+class Eiger1MDetector(SingleTrigger, DetectorBase):
+    
+    cam = ADComponent(EigerDetectorCam_V34, "cam1:")
+    codec1 = ADComponent(CodecPlugin_V34, "Codec1:")
+    image = ADComponent(ImagePlugin, "image1:")
+    roi1 = ADComponent(ROIPlugin, "ROI1:")
+    stats1 = ADComponent(StatsPlugin, "Stats1:")
+    pva = ADComponent(PvaPlugin, "Pva1:")
+
+    hdf1 = ADComponent(
+        XpcsAD_EpicsFileNameHDF5Plugin,
+        "HDF1:",
+        write_path_template=f"{IOC_FILES_ROOT / IMAGE_DIR}/",
+        read_path_template=f"{BLUESKY_FILES_ROOT / IMAGE_DIR}/",
+        kind="normal",
+    )
+
+
+def load_eiger1m(prefix="PV"):
+
+    t0 = time()
+    try:
+        connection_timeout = iconfig.get("PV_CONNECTION_TIMEOUT", 15)
+        eiger1m = Eiger1MDetector(prefix, name="eiger1m")
+        eiger1m.wait_for_connection(timeout=connection_timeout)
+    except (KeyError, NameError, TimeoutError) as exinfo:
+        # fmt: off
+        logger.warning(
+            "Error connecting with PV='%s in %.2fs, %s",
+            prefix, time() - t0, str(exinfo),
+        )
+        logger.warning("Setting eiger1m to 'None'.")
+        eiger1m = None
+        # fmt: on
+
+    else:
+        # just in case these things are not defined in the class source code
+        eiger1m.cam.stage_sigs["wait_for_plugins"] = "Yes"
+        for nm in eiger1m.component_names:
+            obj = getattr(eiger1m, nm)
+            if "blocking_callbacks" in dir(obj):  # is it a plugin?
+                obj.stage_sigs["blocking_callbacks"] = "No"
+
+        plugin = eiger1m.hdf1  # for convenience below
+        plugin.kind = Kind.config | Kind.normal  # Ensure plugin's read is called.
+        plugin.stage_sigs.move_to_end("capture", last=True)
+
+        if iconfig.get("ALLOW_AREA_DETECTOR_WARMUP", False):
+            if eiger1m.connected:
+                if not AD_plugin_primed(plugin):
+                    AD_prime_plugin2(plugin)
+
+    return eiger1m

--- a/instrument/devices/ad_eiger1M.py
+++ b/instrument/devices/ad_eiger1M.py
@@ -67,10 +67,10 @@ class EigerDetectorCam_V34(CamMixin_V34, EigerDetectorCam):
 
 
 from ophyd.areadetector.plugins import HDF5Plugin_V34 as HDF5Plugin
-from ophyd.areadetector.filestore_mixins import FileStoreHDF5SingleIterativeWrite
+from ophyd.areadetector.filestore_mixins import FileStoreHDF5SingleIterativeWrite, FileStoreHDF5Single
 
 
-class AD_EpicsHDF5IterativeWriter(AD_EpicsHdf5FileName, FileStoreHDF5SingleIterativeWrite):
+class AD_EpicsHDF5IterativeWriter(AD_EpicsHdf5FileName, FileStoreHDF5Single):
     pass
 
 class AD_EpicsFileNameHDF5Plugin(HDF5Plugin, AD_EpicsHDF5IterativeWriter):

--- a/instrument/devices/ad_eiger1M.py
+++ b/instrument/devices/ad_eiger1M.py
@@ -137,9 +137,9 @@ class EigerNamedHDF5FileStore(FileStoreHDF5IterativeWrite):
 
     autosave = ADComponent(Signal, value="off", kind="config")
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, write_path_template="", **kwargs):
         # self.filestore_spec = "AD_EIGER_APSPolar"
-        super().__init__(*args, **kwargs)
+        super().__init__(*args, write_path_template, **kwargs)
         self.enable.subscribe(self._set_kind)
         self._base_name = None
 
@@ -299,7 +299,7 @@ class Eiger1MDetector(TriggerTime, DetectorBase):
     hdf1 = ADComponent(
         EigerHDF5Plugin,
         "HDF1:",
-        f"{IOC_FILES_ROOT / IMAGE_DIR}/",
+        write_path_template=f"{IOC_FILES_ROOT / IMAGE_DIR}/",
         read_path_template=f"{BLUESKY_FILES_ROOT / IMAGE_DIR}/",
     )
 

--- a/instrument/devices/ad_eiger1M.py
+++ b/instrument/devices/ad_eiger1M.py
@@ -66,7 +66,7 @@ class EigerDetectorCam_V34(CamMixin_V34, EigerDetectorCam):
     offset = None
 
 
-class XpcsAD_EpicsFileNameHDF5Plugin(PluginMixin, AD_EpicsFileNameHDF5Plugin):
+class EpicsFileNameHDF5Plugin(PluginMixin, AD_EpicsFileNameHDF5Plugin):
     """Remove property attribute not found in AD IOCs now."""
 
     @property
@@ -110,7 +110,7 @@ class Eiger1MDetector(SingleTrigger, DetectorBase):
     pva = ADComponent(PvaPlugin, "Pva1:")
 
     hdf1 = ADComponent(
-        XpcsAD_EpicsFileNameHDF5Plugin,
+        EpicsFileNameHDF5Plugin,
         "HDF1:",
         write_path_template=f"{IOC_FILES_ROOT / IMAGE_DIR}/",
         read_path_template=f"{BLUESKY_FILES_ROOT / IMAGE_DIR}/",
@@ -118,7 +118,7 @@ class Eiger1MDetector(SingleTrigger, DetectorBase):
     )
 
 
-def load_eiger1m(prefix="PV"):
+def load_eiger1m(prefix="4idEiger:"):
 
     t0 = time()
     try:

--- a/instrument/devices/ad_eiger1M.py
+++ b/instrument/devices/ad_eiger1M.py
@@ -283,9 +283,9 @@ def load_eiger1m(prefix="4idEiger:"):
 
         if iconfig.get("ALLOW_AREA_DETECTOR_WARMUP", False):
             if eiger1m.connected:
-                if not AD_plugin_primed(plugin):
-                    AD_prime_plugin2(plugin)
+                if not AD_plugin_primed(eiger1m.hdf1):
+                    AD_prime_plugin2(eiger1m.hdf1)
 
-        # eiger1m.default_settings()
+        eiger1m.default_settings()
 
     return eiger1m

--- a/instrument/devices/ad_eiger1M.py
+++ b/instrument/devices/ad_eiger1M.py
@@ -122,7 +122,7 @@ from datetime import datetime
 from itertools import count
 
 
-class EpicsNameFileStore(FileStoreIterativeWrite):
+class EpicsNameFileStore(FileStoreBase):
 
     # This is the part to change if a different file scheme is chosen.
     def make_write_read_paths(self):
@@ -161,12 +161,15 @@ class EpicsNameFileStore(FileStoreIterativeWrite):
                     "file name."
                 )
             
+            print(self.file_name.get())
 
             # TODO: I don't know why this doesn't work. So need to get the name, and put it back because
             # the super().stage() will change the name.
             self._point_counter = count()
             FileStoreBase.stage(self)
+            
 
+            print(self.file_name.get())
             # TODO: this is a workaround...
 
             # _fname = self.file_name.get()
@@ -188,7 +191,16 @@ class EpicsNameFileStore(FileStoreIterativeWrite):
         super().unstage()
 
 
-class EpicsNameHDF5FileStore(FileStoreHDF5, EpicsNameFileStore):
+class EpicsNameFilestoreIteractiveWrite(FileStoreHDF5IterativeWrite, EpicsNameFileStore):
+    pass
+
+class MyFileStoreHDF5(FileStoreHDF5):
+    def stage(self):
+        res_kwargs = {"frame_per_point": self.get_frames_per_point()}
+        self._generate_resource(res_kwargs)
+
+
+class EpicsNameHDF5FileStore(EpicsNameFilestoreIteractiveWrite, MyFileStoreHDF5):
     pass
 
 

--- a/instrument/devices/ad_eiger1M.py
+++ b/instrument/devices/ad_eiger1M.py
@@ -286,6 +286,6 @@ def load_eiger1m(prefix="4idEiger:"):
                 if not AD_plugin_primed(plugin):
                     AD_prime_plugin2(plugin)
 
-        eiger1m.default_settings()
+        # eiger1m.default_settings()
 
     return eiger1m

--- a/instrument/devices/ad_eiger1M.py
+++ b/instrument/devices/ad_eiger1M.py
@@ -137,11 +137,10 @@ class EigerNamedHDF5FileStore(FileStoreHDF5IterativeWrite):
 
     autosave = ADComponent(Signal, value="off", kind="config")
 
-    def __init__(self, *args, write_path_template="", **kwargs):
+    def __init__(self, write_path_template="", **kwargs):
         # self.filestore_spec = "AD_EIGER_APSPolar"
-        super().__init__(*args, write_path_template, **kwargs)
+        super().__init__(write_path_template, **kwargs)
         self.enable.subscribe(self._set_kind)
-        self._base_name = None
 
         # This is a workaround to enable setting these values in the detector
         # startup. Needed because we don't have a stable solution on where

--- a/instrument/devices/ad_eiger1M.py
+++ b/instrument/devices/ad_eiger1M.py
@@ -137,7 +137,7 @@ class TriggerTime(TriggerBase):
         )
         # This has to be here to ensure it happens after stopping the
         # acquisition.
-        # self.save_images_off()
+        self.save_images_off()
 
     def trigger(self):
         "Trigger one acquisition."

--- a/instrument/devices/ad_eiger1M.py
+++ b/instrument/devices/ad_eiger1M.py
@@ -12,7 +12,7 @@ from ophyd.areadetector.plugins import(
     CodecPlugin_V34
 )
 from apstools.devices import (
-    AD_EpicsFileNameHDF5Plugin, AD_plugin_primed, AD_prime_plugin2, CamMixin_V34
+    AD_EpicsFileNameHDF5Plugin, AD_plugin_primed, AD_prime_plugin2, CamMixin_V34, AD_EpicsHdf5FileName
 )
 from pathlib import PurePath
 from time import time
@@ -64,6 +64,17 @@ class EigerDetectorCam_V34(CamMixin_V34, EigerDetectorCam):
     link_3 = None
     dcu_buff_free = None
     offset = None
+
+
+from ophyd.areadetector.plugins import HDF5Plugin_V34 as HDF5Plugin
+from ophyd.areadetector.filestore_mixins import FileStoreHDF5SingleIterativeWrite
+
+
+class AD_EpicsHDF5IterativeWriter(AD_EpicsHdf5FileName, FileStoreHDF5SingleIterativeWrite):
+    pass
+
+class AD_EpicsFileNameHDF5Plugin(HDF5Plugin, AD_EpicsHDF5IterativeWriter):
+    pass
 
 
 class EpicsFileNameHDF5Plugin(PluginMixin, AD_EpicsFileNameHDF5Plugin):

--- a/instrument/devices/ad_eiger1M.py
+++ b/instrument/devices/ad_eiger1M.py
@@ -69,15 +69,15 @@ class EigerDetectorCam_V34(CamMixin_V34, EigerDetectorCam):
     offset = None
 
 
-from ophyd.areadetector.plugins import HDF5Plugin_V34 as HDF5Plugin
-from ophyd.areadetector.filestore_mixins import FileStoreHDF5SingleIterativeWrite, FileStoreHDF5Single
+# from ophyd.areadetector.plugins import HDF5Plugin_V34 as HDF5Plugin
+# from ophyd.areadetector.filestore_mixins import FileStoreHDF5SingleIterativeWrite, FileStoreHDF5Single
 
 
-class AD_EpicsHDF5IterativeWriter(AD_EpicsHdf5FileName, FileStoreHDF5Single):
-    pass
+# class AD_EpicsHDF5IterativeWriter(AD_EpicsHdf5FileName, FileStoreHDF5Single):
+#     pass
 
-class AD_EpicsFileNameHDF5Plugin(HDF5Plugin, AD_EpicsHDF5IterativeWriter):
-    pass
+# class AD_EpicsFileNameHDF5Plugin(HDF5Plugin, AD_EpicsHDF5IterativeWriter):
+#     pass
 
 
 class TriggerTime(TriggerBase):

--- a/instrument/devices/ad_eiger1M.py
+++ b/instrument/devices/ad_eiger1M.py
@@ -137,7 +137,7 @@ class EigerNamedHDF5FileStore(FileStoreHDF5IterativeWrite):
 
     autosave = ADComponent(Signal, value="off", kind="config")
 
-    def __init__(self, *args, write_path_template, read_path_template, **kwargs):
+    def __init__(self, *args, write_path_template="", read_path_template="", **kwargs):
         # self.filestore_spec = "AD_EIGER_APSPolar"
         super().__init__(*args, **kwargs)
         self.enable.subscribe(self._set_kind)

--- a/instrument/devices/ad_eiger1M.py
+++ b/instrument/devices/ad_eiger1M.py
@@ -137,7 +137,7 @@ class TriggerTime(TriggerBase):
         )
         # This has to be here to ensure it happens after stopping the
         # acquisition.
-        self.save_images_off()
+        # self.save_images_off()
 
     def trigger(self):
         "Trigger one acquisition."

--- a/instrument/devices/ad_eiger1M.py
+++ b/instrument/devices/ad_eiger1M.py
@@ -154,7 +154,7 @@ class TriggerTime(TriggerBase):
 
         self._status = self._status_type(self)
         self._acquisition_signal.put(1, wait=False)
-        self.dispatch(self._image_name, ttime())
+        self.generate_datum(self._image_name, ttime())
         add_delay(self._status, self._min_period)
         return self._status
 

--- a/instrument/devices/ad_eiger1M.py
+++ b/instrument/devices/ad_eiger1M.py
@@ -137,7 +137,7 @@ class EigerNamedHDF5FileStore(FileStoreHDF5IterativeWrite):
 
     autosave = ADComponent(Signal, value="off", kind="config")
 
-    def __init__(self, *args, write_path_template="", read_path_template="", **kwargs):
+    def __init__(self, *args, **kwargs):
         # self.filestore_spec = "AD_EIGER_APSPolar"
         super().__init__(*args, **kwargs)
         self.enable.subscribe(self._set_kind)
@@ -146,9 +146,6 @@ class EigerNamedHDF5FileStore(FileStoreHDF5IterativeWrite):
         # This is a workaround to enable setting these values in the detector
         # startup. Needed because we don't have a stable solution on where
         # these images would be.
-        self.write_path_template = write_path_template
-        self.read_path_template = read_path_template
-        self._status_stash = None
 
     def _set_kind(self, value, **kwargs):
         if value in (True, 1, "on", "Enable"):
@@ -302,7 +299,7 @@ class Eiger1MDetector(TriggerTime, DetectorBase):
     hdf1 = ADComponent(
         EigerHDF5Plugin,
         "HDF1:",
-        write_path_template=f"{IOC_FILES_ROOT / IMAGE_DIR}/",
+        f"{IOC_FILES_ROOT / IMAGE_DIR}/",
         read_path_template=f"{BLUESKY_FILES_ROOT / IMAGE_DIR}/",
     )
 

--- a/instrument/devices/ad_eiger1M.py
+++ b/instrument/devices/ad_eiger1M.py
@@ -69,15 +69,15 @@ class EigerDetectorCam_V34(CamMixin_V34, EigerDetectorCam):
     offset = None
 
 
-# from ophyd.areadetector.plugins import HDF5Plugin_V34 as HDF5Plugin
-# from ophyd.areadetector.filestore_mixins import FileStoreHDF5SingleIterativeWrite, FileStoreHDF5Single
+from ophyd.areadetector.plugins import HDF5Plugin_V34 as HDF5Plugin
+from ophyd.areadetector.filestore_mixins import FileStoreHDF5SingleIterativeWrite, FileStoreHDF5Single
 
 
-# class AD_EpicsHDF5IterativeWriter(AD_EpicsHdf5FileName, FileStoreHDF5Single):
-#     pass
+class AD_EpicsHDF5IterativeWriter(AD_EpicsHdf5FileName, FileStoreHDF5Single):
+    pass
 
-# class AD_EpicsFileNameHDF5Plugin(HDF5Plugin, AD_EpicsHDF5IterativeWriter):
-#     pass
+class AD_EpicsFileNameHDF5Plugin(HDF5Plugin, AD_EpicsHDF5IterativeWriter):
+    pass
 
 
 class TriggerTime(TriggerBase):

--- a/instrument/devices/ad_eiger1M.py
+++ b/instrument/devices/ad_eiger1M.py
@@ -66,15 +66,15 @@ class EigerDetectorCam_V34(CamMixin_V34, EigerDetectorCam):
     offset = None
 
 
-from ophyd.areadetector.plugins import HDF5Plugin_V34 as HDF5Plugin
-from ophyd.areadetector.filestore_mixins import FileStoreHDF5SingleIterativeWrite, FileStoreHDF5Single
+# from ophyd.areadetector.plugins import HDF5Plugin_V34 as HDF5Plugin
+# from ophyd.areadetector.filestore_mixins import FileStoreHDF5SingleIterativeWrite, FileStoreHDF5Single
 
 
-class AD_EpicsHDF5IterativeWriter(AD_EpicsHdf5FileName, FileStoreHDF5Single):
-    pass
+# class AD_EpicsHDF5IterativeWriter(AD_EpicsHdf5FileName, FileStoreHDF5Single):
+#     pass
 
-class AD_EpicsFileNameHDF5Plugin(HDF5Plugin, AD_EpicsHDF5IterativeWriter):
-    pass
+# class AD_EpicsFileNameHDF5Plugin(HDF5Plugin, AD_EpicsHDF5IterativeWriter):
+#     pass
 
 
 class EpicsFileNameHDF5Plugin(PluginMixin, AD_EpicsFileNameHDF5Plugin):

--- a/instrument/devices/ad_eiger1M.py
+++ b/instrument/devices/ad_eiger1M.py
@@ -178,19 +178,6 @@ class FileStoreHDF5IterativeWriteEpicsName(FileStorePluginBaseEpicsName):
         return super().generate_datum(key, timestamp, datum_kwargs)
 
 
-# class EpicsNameFilestoreIteractiveWrite(FileStoreHDF5IterativeWrite, EpicsNameFileStore):
-#     pass
-
-# class MyFileStoreHDF5(FileStoreHDF5):
-#     def stage(self):
-#         res_kwargs = {"frame_per_point": self.get_frames_per_point()}
-#         self._generate_resource(res_kwargs)
-
-
-# class EpicsNameHDF5FileStore(EpicsNameFilestoreIteractiveWrite, MyFileStoreHDF5):
-#     pass
-
-
 class HDF5Plugin(PluginMixin, HDF5Plugin_V34):
     pass
 
@@ -200,16 +187,7 @@ class EigerHDF5Plugin(HDF5Plugin, FileStoreHDF5IterativeWriteEpicsName):
     """
     Using the filename from EPICS.
     """
-    # seq_id = ADComponent(EpicsSignalRO, "SequenceId")
-    # file_path = ADComponent(EpicsSignalWithRBV, 'FilePath', string=True,
-    #                         put_complete=True)
-    # file_write_name_pattern = ADComponent(EpicsSignalWithRBV, 'FWNamePattern',
-    #                                       string=True, put_complete=True)
-    # file_write_images_per_file = ADComponent(EpicsSignalWithRBV,
-    #                                          'FWNImagesPerFile')
-    # current_run_start_uid = Component(Signal, value='', add_prefix=())
-    # num_images_counter = ADComponent(EpicsSignalRO, 'NumImagesCounter_RBV')
-    # enable = Component(Signal, value=False, kind="omitted")
+
     autosave = ADComponent(Signal, value="off", kind="config")
 
     def __init__(self, *args, write_path_template="", **kwargs):
@@ -282,16 +260,13 @@ class TriggerTime(TriggerBase):
             "Return True when detector is done"
             return (value == "Ready" or value == "Acquisition aborted")
 
-        # When stopping the detector, it may take some time processing the
-        # images. This will block until it's done.
+        # When stopping the detector, it may take some time processing the images.
+        # This will block until it's done.
         status_wait(
             SubscriptionStatus(
                 self.cam.status_message, check_value, timeout=10
             )
         )
-        # This has to be here to ensure it happens after stopping the
-        # acquisition.
-        # self.save_images_off()
 
     def trigger(self):
         "Trigger one acquisition."
@@ -372,11 +347,12 @@ class Eiger1MDetector(TriggerTime, DetectorBase):
         self.hdf1.file_template.put("%s%s_%6.6d.h5")
         self.hdf1.num_capture.put(0)
 
+        self.hdf1.stage_sigs.pop("enable")
+        self.hdf1.stage_sigs["num_capture"] = 0
+    
         self.setup_manual_trigger()
         self.save_images_off()
         self.plot_roi1()
-        self.hdf1.stage_sigs.pop("enable")
-        self.hdf1.stage_sigs["num_capture"] = 0
 
     def plot_roi1(self):
         self.stats1.total.kind="hinted"

--- a/instrument/devices/ad_eiger1M.py
+++ b/instrument/devices/ad_eiger1M.py
@@ -242,7 +242,6 @@ class Eiger1MDetector(TriggerTime, DetectorBase):
         self.cam.manual_trigger.put("Disable")
         self.cam.trigger_mode.put("Internal Enable")
         self.cam.acquire.put(0)
-        self.file.enable.put(True)
         self.setup_manual_trigger()
         self.save_images_off()
         self.plot_roi1()

--- a/instrument/devices/ad_mixins.py
+++ b/instrument/devices/ad_mixins.py
@@ -78,8 +78,9 @@ class FileStorePluginBaseEpicsName(FileStoreBase):
                 ("num_capture", 0),
             ]
         )
-        self._fn = ""
-        self._fp = ""
+        # This is needed if you want to start bluesky and run a no-image scan first.
+        self._fn = None
+        self._fp = None
 
     # This is the part to change if a different file scheme is chosen.
     def make_write_read_paths(self):
@@ -157,6 +158,8 @@ class FileStoreHDF5IterativeWriteEpicsName(FileStorePluginBaseEpicsName):
     def stage(self):
         super().stage()
         res_kwargs = {"frame_per_point": self.get_frames_per_point()}
+        if self._fn is None:
+            self._fn = self.hdf1.reg_root
         self._generate_resource(res_kwargs)
         self._point_counter = count()
 

--- a/instrument/devices/ad_mixins.py
+++ b/instrument/devices/ad_mixins.py
@@ -159,7 +159,7 @@ class FileStoreHDF5IterativeWriteEpicsName(FileStorePluginBaseEpicsName):
         super().stage()
         res_kwargs = {"frame_per_point": self.get_frames_per_point()}
         if self._fn is None:
-            self._fn = self.hdf1.reg_root
+            self._fn = self.reg_root
         self._generate_resource(res_kwargs)
         self._point_counter = count()
 

--- a/instrument/devices/ad_mixins.py
+++ b/instrument/devices/ad_mixins.py
@@ -1,0 +1,210 @@
+""" AD mixins """
+
+from ophyd import ADComponent, EpicsSignal, Signal
+from ophyd.areadetector import EigerDetectorCam
+from ophyd.areadetector.plugins import(
+    PluginBase_V34,
+    ImagePlugin_V34,
+    PvaPlugin_V34,
+    ROIPlugin_V34,
+    StatsPlugin_V34,
+    CodecPlugin_V34,
+    HDF5Plugin_V34
+)
+from ophyd.areadetector.filestore_mixins import FileStoreBase
+from apstools.devices import CamMixin_V34
+from pathlib import PurePath
+from os.path import isfile
+from datetime import datetime
+from itertools import count
+from .. import iconfig  # noqa
+from ..session_logs import logger
+logger.info(__file__)
+
+BLUESKY_FILES_ROOT = PurePath(iconfig["AREA_DETECTOR"]["BLUESKY_FILES_ROOT"])
+IOC_FILES_ROOT = PurePath(iconfig["AREA_DETECTOR"]["EIGER_1M"]["IOC_FILES_ROOT"])
+IMAGE_DIR = iconfig["AREA_DETECTOR"].get("IMAGE_DIR", "%Y/%m/%d/")
+
+
+class PluginMixin(PluginBase_V34):
+    """Remove property attribute found in AD IOCs now."""
+
+    _asyn_pipeline_configuration_names = None
+
+
+class ImagePlugin(PluginMixin, ImagePlugin_V34):
+    """Remove property attribute found in AD IOCs now."""
+
+
+class PvaPlugin(PluginMixin, PvaPlugin_V34):
+    """Remove property attribute found in AD IOCs now."""
+
+
+class ROIPlugin(PluginMixin, ROIPlugin_V34):
+    """Remove property attribute found in AD IOCs now."""
+
+
+class StatsPlugin(PluginMixin, StatsPlugin_V34):
+    """Remove property attribute found in AD IOCs now."""
+
+
+class CodecPlugin(PluginMixin, CodecPlugin_V34):
+    """Remove property attribute found in AD IOCs now."""
+
+
+class EigerDetectorCam(CamMixin_V34, EigerDetectorCam):
+    """Revise EigerDetectorCam for ADCore revisions."""
+
+    initialize = ADComponent(EpicsSignal, "Initialize", kind="config")
+
+    # These components not found on Eiger 4M at 8-ID-I
+    file_number_sync = None
+    file_number_write = None
+    fw_clear = None
+    link_0 = None
+    link_1 = None
+    link_2 = None
+    link_3 = None
+    dcu_buff_free = None
+    offset = None
+
+
+class FileStorePluginBaseEpicsName(FileStoreBase):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if hasattr(self, "create_directory"):
+            self.stage_sigs.update({"create_directory": -3})
+        self.stage_sigs.update(
+            [
+                ("auto_increment", "Yes"),
+                ("array_counter", 0),
+                ("auto_save", "Yes"),
+                ("num_capture", 0),
+            ]
+        )
+        self._fn = None
+        self._fp = None
+
+    # This is the part to change if a different file scheme is chosen.
+    def make_write_read_paths(self):
+        # Folders - this allows for using dates for folders.
+        formatter = datetime.now().strftime
+        write_path = formatter(self.write_path_template)
+        read_path = formatter(self.read_path_template)
+
+        # File name -- assumes some sort of %s%s_5.5%d.h5 format
+        file_read = self.file_template.get() % (
+            read_path,
+            self.file_name.get(),
+            int(self.file_number.get())
+        )
+
+        file_write = self.file_template.get() % (
+            write_path + "/",
+            self.file_name.get(),
+            int(self.file_number.get())
+        )
+
+        return write_path, file_write, read_path, file_read
+
+    def stage(self):
+
+        # Only save images if the enable is on...
+        if self.enable.get() in (True, 1, "on", "Enable"):
+
+            if self.file_write_mode.get(as_string=True) != "Single":
+                self.capture.set(0).wait()
+            
+            write_path, file_write, read_path, file_read = self.make_write_read_paths()
+
+            if isfile(file_write):
+                raise OSError(
+                    f"{file_write} already exists! Cannot overwrite it, so please "
+                    "change the file name."
+                )
+
+            self.file_path.set(write_path).wait()
+            super().stage()
+
+            self._fn = file_read
+            self._fp = read_path
+            if not self.file_path_exists.get():
+                raise IOError(
+                    "Path %s does not exist on IOC." "" % self.file_path.get()
+                )
+
+
+class FileStoreHDF5IterativeWriteEpicsName(FileStorePluginBaseEpicsName):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.filestore_spec = "AD_HDF5"  # spec name stored in resource doc
+        self.stage_sigs.update(
+            [
+                ("file_template", "%s%s_%6.6d.h5"),
+                ("file_write_mode", "Stream"),
+                ("capture", 1),
+            ]
+        )
+        self._point_counter = None
+
+    def get_frames_per_point(self):
+        num_capture = self.num_capture.get()
+        # If num_capture is 0, then the plugin will capture however many frames
+        # it is sent. We can get how frames it will be sent (unless
+        # interrupted) by consulting num_images on the detector's camera.
+        if num_capture == 0:
+            return self.parent.cam.num_images.get()
+        # Otherwise, a nonzero num_capture will cut off capturing at the
+        # specified number.
+        return num_capture
+
+    def stage(self):
+        super().stage()
+        res_kwargs = {"frame_per_point": self.get_frames_per_point()}
+        self._generate_resource(res_kwargs)
+        self._point_counter = count()
+
+    def unstage(self):
+        self._point_counter = None
+        super().unstage()
+
+    def generate_datum(self, key, timestamp, datum_kwargs):
+        i = next(self._point_counter)
+        datum_kwargs = datum_kwargs or {}
+        datum_kwargs.update({"point_number": i})
+        return super().generate_datum(key, timestamp, datum_kwargs)
+
+
+class HDF5Plugin(PluginMixin, HDF5Plugin_V34):
+    pass
+
+
+class EigerHDF5Plugin(HDF5Plugin, FileStoreHDF5IterativeWriteEpicsName):
+
+    """
+    Using the filename from EPICS.
+    """
+
+    autosave = ADComponent(Signal, value="off", kind="config")
+
+    def __init__(self, *args, write_path_template="", **kwargs):
+        # self.filestore_spec = "AD_EIGER_APSPolar"
+        super().__init__(*args, write_path_template=write_path_template, **kwargs)
+        self.enable.subscribe(self._setup_kind)
+
+    def _setup_kind(self, value, **kwargs):
+        if value in (True, 1, "on", "Enable"):
+            self.kind = "normal"
+        else:
+            self.kind = "omitted"
+
+    def stage(self):
+        if self.autosave.get() in (True, 1, "on", "Enable"):
+            self.parent.save_images_on()
+        super().stage()
+
+    def unstage(self):
+        if self.autosave.get() in (True, 1, "on", "Enable"):
+            self.parent.save_images_off()
+        super().unstage()

--- a/instrument/devices/ad_mixins.py
+++ b/instrument/devices/ad_mixins.py
@@ -17,13 +17,8 @@ from pathlib import PurePath
 from os.path import isfile
 from datetime import datetime
 from itertools import count
-from .. import iconfig  # noqa
 from ..session_logs import logger
 logger.info(__file__)
-
-BLUESKY_FILES_ROOT = PurePath(iconfig["AREA_DETECTOR"]["BLUESKY_FILES_ROOT"])
-IOC_FILES_ROOT = PurePath(iconfig["AREA_DETECTOR"]["EIGER_1M"]["IOC_FILES_ROOT"])
-IMAGE_DIR = iconfig["AREA_DETECTOR"].get("IMAGE_DIR", "%Y/%m/%d/")
 
 
 class PluginMixin(PluginBase_V34):
@@ -83,8 +78,8 @@ class FileStorePluginBaseEpicsName(FileStoreBase):
                 ("num_capture", 0),
             ]
         )
-        self._fn = None
-        self._fp = None
+        self._fn = ""
+        self._fp = ""
 
     # This is the part to change if a different file scheme is chosen.
     def make_write_read_paths(self):

--- a/instrument/devices/interferometers_4IDG.py
+++ b/instrument/devices/interferometers_4IDG.py
@@ -1,7 +1,10 @@
+""" Interferometer setup """
+
 __all__ = ["interferometer"]
 
 from ophyd import Device, Component, EpicsSignalRO
-
+from ..session_logs import logger
+logger.info(__file__)
 
 class InterferometerDevice(Device):
   mhor_up = Component(EpicsSignalRO, "pixelTrig-1_POS1")

--- a/instrument/iconfig.yml
+++ b/instrument/iconfig.yml
@@ -42,7 +42,7 @@ AREA_DETECTOR:
   BLUESKY_FILES_ROOT: &BLUESKY_DATA_ROOT "/home/beams/POLAR/data/bluesky_images/eiger1M_test"
   IMAGE_DIR: "%Y/%m/%d/"
   HDF5_FILE_TEMPLATE: "%s%s_%6.6d.h5"
-  EIGER_4M:
+  EIGER_1M:
     # IOC host: beryl:/net/s8iddserv/xorApps/epics/synApps_6_2_1/ioc/8idEiger4m/iocBoot/ioc8idEiger4m/softioc/8idEiger4m.pl status
     # Same filesystem
     # IOC_FILES_ROOT: *BLUESKY_DATA_ROOT

--- a/instrument/iconfig.yml
+++ b/instrument/iconfig.yml
@@ -45,8 +45,7 @@ AREA_DETECTOR:
   EIGER_1M:
     # IOC host: beryl:/net/s8iddserv/xorApps/epics/synApps_6_2_1/ioc/8idEiger4m/iocBoot/ioc8idEiger4m/softioc/8idEiger4m.pl status
     # Same filesystem
-    # IOC_FILES_ROOT: *BLUESKY_DATA_ROOT
-    IOC_FILES_ROOT: "CHANGE THIS!!!"
+    IOC_FILES_ROOT: *BLUESKY_DATA_ROOT
     # NAME: eiger4M
     # PV_PREFIX: "8idEiger4m:"
 

--- a/instrument/iconfig.yml
+++ b/instrument/iconfig.yml
@@ -37,6 +37,21 @@ WRITE_SPEC_DATA_FILES: true
 
 # ----------------------------------
 
+AREA_DETECTOR:
+  # TODO: switch to the Voyager-based path structure: "/gdata/..."
+  BLUESKY_FILES_ROOT: &BLUESKY_DATA_ROOT "/home/beams/POLAR/data/bluesky_images/eiger1M_test"
+  IMAGE_DIR: "%Y/%m/%d/"
+  HDF5_FILE_TEMPLATE: "%s%s_%6.6d.h5"
+  EIGER_4M:
+    # IOC host: beryl:/net/s8iddserv/xorApps/epics/synApps_6_2_1/ioc/8idEiger4m/iocBoot/ioc8idEiger4m/softioc/8idEiger4m.pl status
+    # Same filesystem
+    # IOC_FILES_ROOT: *BLUESKY_DATA_ROOT
+    IOC_FILES_ROOT: "CHANGE THIS!!!"
+    # NAME: eiger4M
+    # PV_PREFIX: "8idEiger4m:"
+
+# ----------------------------------
+
 # Directory to "autosave" the RE.md dictionary (uses PersistentDict)
 # Uncomment and modify to change from the default.
 RUNENGINE_MD_PATH: /home/beams/POLAR/.config/Bluesky_RunEngine_md


### PR DESCRIPTION
Initial setup of the Eiger1M. Some comments:

- Used the areadetector HDF5 plugin.
- Images are saved using the EPICS name.
- It will raise an `OSError` if the image already exists.
- Saves all images of a scan into a single HDF5.
- The trigger is time based, the wait time is set by `eiger1m.min_period`. I found that we need at least 0.2s between two consecutive EPICS triggers, so this `min_period` should be 0.2s. Bluesky will wait for `min_period` if acquisition time < min_period, else it will wait for acquisition time (for example, if you count for 1s it will wait for 1s , but it count is 0.1s, then the wait is 0.2s). In other words, it doesn't make sense to make to run a step scan with less than 0.2s per point.