### PR TITLE
Initial setup of a more general plotselect

### DIFF
--- a/src/instrument/devices/ad_vimba.py
+++ b/src/instrument/devices/ad_vimba.py
@@ -311,3 +311,16 @@ class VimbaDetector(Trigger, DetectorBase):
         _hdf1_auto = True if self.hdf1.autosave.get() == "on" else False
         _hdf1_on = True if self.hdf1.enable.get() == "Enable" else False
         return _hdf1_on or _hdf1_auto
+
+    @property
+    def label_option_map(self):
+        return {f"ROI{i} Total": i for i in range(1, 5)}
+
+    @property
+    def plot_options(self):
+        # Return all named scaler channels
+        return list(self.label_option_map.keys())
+
+    def select_plot(self, channels):
+        chans = [self.label_option_map[i] for i in channels]
+        self.plot_select(chans)

--- a/src/instrument/devices/counters_class.py
+++ b/src/instrument/devices/counters_class.py
@@ -303,18 +303,22 @@ class CountersClass:
             )
             mon = 0
         else:
-            mon = self.detectors_plot_options[
+            _mon = self.detectors_plot_options[
                 self.detectors_plot_options == self.monitor
             ].index[0]
             while True:
                 mon = input(
-                    f"Enter index number of monitor detector [{mon}]: "
-                ) or mon
+                    f"Enter index number of monitor detector [{_mon}]: "
+                ) or _mon
 
                 try:
                     mon = int(mon)
                 except ValueError:
                     print("Please enter the index number only.")
+                    continue
+
+                if mon > self.detectors_plot_options.size:
+                    print(f"Monitor index {mon} is invalid.")
                     continue
 
                 if (

--- a/src/instrument/devices/counters_class.py
+++ b/src/instrument/devices/counters_class.py
@@ -287,6 +287,9 @@ class CountersClass:
             getattr(det, "select_plot")(group["channels"].values)
             dets.append(det)
 
+        if self.default_scaler not in dets:
+            dets.append(self.default_scaler)
+
         self._dets = dets
 
     def plotselect(self):

--- a/src/instrument/devices/counters_class.py
+++ b/src/instrument/devices/counters_class.py
@@ -160,6 +160,12 @@ class CountersClass:
             except TypeError:
                 value = [value]
 
+            # This prevents double of the default scaler.
+            try:
+                value.remove(self._default_scaler)
+            except ValueError:
+                pass
+
             # self._dets will hold the device instance.
             # default scaler is always a detector even if it's not plotted.
             self._dets = [self._default_scaler]
@@ -269,17 +275,19 @@ class CountersClass:
         return DataFrame(table)
 
     def select_plot_channels(self, selection):
-        # selection will be a list with the indexes.
+
         groups = self.detectors_plot_options.iloc[
             list(selection)
         ].groupby("detectors")
 
+        dets = []
         for name, group in groups:
             det = oregistry.find(name)
-            if det not in self.detectors:
-                self.detectors += [det]
             # det.select_plot(item) selects that channel to plot.
             getattr(det, "select_plot")(group["channels"].values)
+            dets.append(det)
+
+        self.__call__(dets)
 
     def plotselect(self):
         print("Options:")

--- a/src/instrument/devices/counters_class.py
+++ b/src/instrument/devices/counters_class.py
@@ -237,7 +237,7 @@ class CountersClass:
 
     @property
     def _available_detectors(self):
-        return oregistry.find_all("detector")
+        return oregistry.findall("detector")
 
     @property
     def detectors_plot_options(self):
@@ -259,7 +259,7 @@ class CountersClass:
             det = self.detectors_plot_options.loc[ind]["detectors"]
             if det not in self.detectors:
                 self.detectors += [det]
-            # det.select_plotting(item) selects that channel to plot.
+            # det.select_plot(item) selects that channel to plot.
 
             channel = self.detectors_plot_options.loc[ind]["channels"]
             # TODO: this may be unnecessary. Maybe we can use oregistry to get

--- a/src/instrument/devices/counters_class.py
+++ b/src/instrument/devices/counters_class.py
@@ -1,3 +1,4 @@
+from pandas import DataFrame
 from .simulated_scaler import scaler_sim
 from ..utils.oregistry_setup import oregistry
 from ..utils._logging_setup import logger
@@ -239,23 +240,31 @@ class CountersClass:
         return oregistry.find_all("detector")
 
     @property
-    def detectors_channels(self):
-        channels = {}
+    def detectors_plot_options(self):
+        table = dict(detectors=[], channels=[])
         for det in self._available_detectors:
-            # det.get_plotting_options will return a list of available plotting
-            # options.
-            for option in getattr(det, "get_plotting_options", []):
-                channels[option] = det
+            # det.get_plot_options will return a list of available
+            # plotting options.
+            _options = getattr(det, "get_plot_options", [])
+            table["channels"] += _options
+            table["detectors"] += [det.name for _ in range(len(_options))]
 
-        return channels
+        # This will be a table with all the options, it will have the advantage
+        # that it can be indexed.
+        return DataFrame(table)
 
-    def select_plotting(self, selection):
-        for item in selection:
-            det = self.detectors_channels[item]
+    def select_plot_channels(self, selection):
+        # selection will be the numbers.
+        for ind in selection:
+            det = self.detectors_plot_options.loc[ind]["detectors"]
             if det not in self.detectors:
                 self.detectors += [det]
             # det.select_plotting(item) selects that channel to plot.
-            getattr(det, "select_plotting")(item)
+
+            channel = self.detectors_plot_options.loc[ind]["channels"]
+            # TODO: this may be unnecessary. Maybe we can use oregistry to get
+            # the specific item from the name?
+            getattr(det, "select_plot")(channel)
 
 
 counters = CountersClass()

--- a/src/instrument/devices/counters_class.py
+++ b/src/instrument/devices/counters_class.py
@@ -289,6 +289,7 @@ class CountersClass:
 
         if self.default_scaler not in dets:
             dets.append(self.default_scaler)
+            self.default_scaler.select_plot_channels([''])
 
         self._dets = dets
 

--- a/src/instrument/devices/counters_class.py
+++ b/src/instrument/devices/counters_class.py
@@ -285,6 +285,7 @@ class CountersClass:
             det = oregistry.find(name)
             # det.select_plot(item) selects that channel to plot.
             getattr(det, "select_plot")(group["channels"].values)
+            print(det.name, group["channels"].values)
             dets.append(det)
 
         self.__call__(dets)

--- a/src/instrument/devices/counters_class.py
+++ b/src/instrument/devices/counters_class.py
@@ -1,4 +1,5 @@
 from pandas import DataFrame
+from ophydregistry import ComponentNotFound
 from .simulated_scaler import scaler_sim
 from ..utils.oregistry_setup import oregistry
 from ..utils._logging_setup import logger
@@ -237,7 +238,21 @@ class CountersClass:
 
     @property
     def _available_detectors(self):
-        return oregistry.findall("detector")
+        try:
+            dets = oregistry.findall("detector")
+        except ComponentNotFound:
+            logger.warning("WARNING: no detectors were found by oregistry.")
+            dets = []
+
+        try:
+            dets.remove(self.default_scaler)
+        except ValueError:
+            logger.warning(
+                f"WARNING: the {counters.default_scaler.name} was not found by"
+                "oregistry."
+            )
+
+        return [self.default_scaler] + dets
 
     @property
     def detectors_plot_options(self):

--- a/src/instrument/devices/counters_class.py
+++ b/src/instrument/devices/counters_class.py
@@ -280,18 +280,20 @@ class CountersClass:
             list(selection)
         ].groupby("detectors")
 
-        print("5")
         dets = []
         for name, group in groups:
             det = oregistry.find(name)
+            print(name, group)
             # det.select_plot(item) selects that channel to plot.
             getattr(det, "select_plot")(group["channels"].values)
             dets.append(det)
 
+        print("1")
         if self.default_scaler not in dets:
             dets.append(self.default_scaler)
             self.default_scaler.select_plot_channels([''])
 
+        print("2")
         self._dets = dets
 
     def plotselect(self):
@@ -301,12 +303,10 @@ class CountersClass:
         while True:
             dets = input("Enter the indexes of plotting channels: ") or None
 
-            print("1")
             if dets is None:
                 print("A value must be entered.")
                 continue
 
-            print("2")
             # Check these are all numbers
             try:
                 dets = [int(i) for i in dets.split()]
@@ -314,14 +314,13 @@ class CountersClass:
                 print("Please enter the index numbers only.")
                 continue
 
-            print("3")
             # Check that the numbers are valid.
             if not all(
                 [i in self.detectors_plot_options.index.values for i in dets]
             ):
                 print("The index values must be in the table.")
                 continue
-            print("4")
+
             self.select_plot_channels(dets)
             break
 

--- a/src/instrument/devices/counters_class.py
+++ b/src/instrument/devices/counters_class.py
@@ -283,12 +283,13 @@ class CountersClass:
         dets = []
         for name, group in groups:
             det = oregistry.find(name)
-            print(name, group)
+            print("\n", name, "\n", group)
             # det.select_plot(item) selects that channel to plot.
             getattr(det, "select_plot")(group["channels"].values)
+            print("1")
             dets.append(det)
 
-        print("1")
+        print("2")
         if self.default_scaler not in dets:
             dets.append(self.default_scaler)
             self.default_scaler.select_plot_channels([''])

--- a/src/instrument/devices/counters_class.py
+++ b/src/instrument/devices/counters_class.py
@@ -285,10 +285,9 @@ class CountersClass:
             det = oregistry.find(name)
             # det.select_plot(item) selects that channel to plot.
             getattr(det, "select_plot")(group["channels"].values)
-            print(det.name, group["channels"].values)
             dets.append(det)
 
-        self.__call__(dets)
+        self.detectors = dets
 
     def plotselect(self):
         print("Options:")

--- a/src/instrument/devices/counters_class.py
+++ b/src/instrument/devices/counters_class.py
@@ -296,6 +296,7 @@ class CountersClass:
     def plotselect(self):
         print("Options:")
         print(self.detectors_plot_options)
+        print("")
 
         while True:
             dets = input("Enter the indexes of plotting channels: ") or None

--- a/src/instrument/devices/counters_class.py
+++ b/src/instrument/devices/counters_class.py
@@ -271,7 +271,11 @@ class CountersClass:
         print(self.detectors_plot_options)
 
         while True:
-            dets = input("Enter the indexes of plotting channels: ")
+            dets = input("Enter the indexes of plotting channels: ") or None
+
+            if dets is None:
+                print("A value must be entered.")
+                continue
 
             # Check these are all numbers
             try:
@@ -290,11 +294,11 @@ class CountersClass:
             self.select_plot_channels(dets)
             break
 
-        selection = self.detectors_plot_options.iloc[dets]
+        selection = self.detectors_plot_options.iloc[dets].detectors.values
         # if any detector is not a scaler, then count agains time!
         if any(["scaler" not in i for i in selection]):
             print(
-                "One of the detectors is not a scaler, so 'Time' will be"
+                "One of the detectors is not a scaler, so 'Time' will be "
                 "selected as monitor."
             )
             mon = 0

--- a/src/instrument/devices/counters_class.py
+++ b/src/instrument/devices/counters_class.py
@@ -234,5 +234,27 @@ class CountersClass:
                 raise TypeError("counts need to be a number, but "
                                 f"{type(value)} was entered.")
 
+    @property
+    def _available_detectors(self):
+        return oregistry.find_all("detector")
+    
+    @property
+    def detectors_channels(self):
+        channels = {}
+        for det in self._available_detectors:
+            # det.get_plotting_options will return a list of available plotting
+            # options.
+            for option in getattr(det, "get_plotting_options", []):
+                channels[option] = det
+        
+        return channels
+
+    def select_plotting(self, selection):
+        for item in selection:
+            det = self.detectors_channels[item]
+            if det not in self.detectors:
+                self.detectors += [det]
+            # det.select_plotting(item) selects that channel to plot.
+            getattr(det, "select_plotting")(item)
 
 counters = CountersClass()

--- a/src/instrument/devices/counters_class.py
+++ b/src/instrument/devices/counters_class.py
@@ -306,11 +306,30 @@ class CountersClass:
             mon = self.detectors_plot_options[
                 self.detectors_plot_options == self.monitor
             ].index[0]
-            mon = input(
-                f"Enter index number of monitor detector [{mon}]: "
-            ) or mon
+            while True:
+                mon = input(
+                    f"Enter index number of monitor detector [{mon}]: "
+                ) or mon
 
-        self.monitor = self.detectors_plot_options.iloc[mon].channels
+                try:
+                    mon = int(mon)
+                except ValueError:
+                    print("Please enter the index number only.")
+                    continue
+
+                if (
+                    "scaler" not in
+                    self.detectors_plot_options.iloc[mon].detectors
+                ):
+                    print("Monitor must be a scaler channel.")
+                    continue
+
+                break
+
+        self.monitor = mon
+
+        print()
+        print(self)
 
 
 counters = CountersClass()

--- a/src/instrument/devices/counters_class.py
+++ b/src/instrument/devices/counters_class.py
@@ -280,6 +280,7 @@ class CountersClass:
             list(selection)
         ].groupby("detectors")
 
+        print("5")
         dets = []
         for name, group in groups:
             det = oregistry.find(name)
@@ -300,10 +301,12 @@ class CountersClass:
         while True:
             dets = input("Enter the indexes of plotting channels: ") or None
 
+            print("1")
             if dets is None:
                 print("A value must be entered.")
                 continue
 
+            print("2")
             # Check these are all numbers
             try:
                 dets = [int(i) for i in dets.split()]
@@ -311,13 +314,14 @@ class CountersClass:
                 print("Please enter the index numbers only.")
                 continue
 
+            print("3")
             # Check that the numbers are valid.
             if not all(
                 [i in self.detectors_plot_options.index.values for i in dets]
             ):
                 print("The index values must be in the table.")
                 continue
-
+            print("4")
             self.select_plot_channels(dets)
             break
 

--- a/src/instrument/devices/counters_class.py
+++ b/src/instrument/devices/counters_class.py
@@ -285,7 +285,7 @@ class CountersClass:
             det = oregistry.find(name)
             print("\n", name, "\n", group)
             # det.select_plot(item) selects that channel to plot.
-            getattr(det, "select_plot")(group["channels"].values)
+            # getattr(det, "select_plot")(group["channels"].values)
             print("1")
             dets.append(det)
 

--- a/src/instrument/devices/counters_class.py
+++ b/src/instrument/devices/counters_class.py
@@ -307,10 +307,10 @@ class CountersClass:
                 self.detectors_plot_options == self.monitor
             ].index[0]
             mon = input(
-                "Enter index number of monitor detector [{mon}]: "
+                f"Enter index number of monitor detector [{mon}]: "
             ) or mon
 
-        self.monitor = mon
+        self.monitor = self.detectors_plot_options.iloc[mon].channels
 
 
 counters = CountersClass()

--- a/src/instrument/devices/counters_class.py
+++ b/src/instrument/devices/counters_class.py
@@ -285,7 +285,10 @@ class CountersClass:
             det = oregistry.find(name)
             print("\n", name, "\n", group)
             # det.select_plot(item) selects that channel to plot.
-            # getattr(det, "select_plot")(group["channels"].values)
+            func = getattr(det, "select_plot")
+            print("0")
+            print(group["channels"].values)
+            func(group["channels"].values)
             print("1")
             dets.append(det)
 

--- a/src/instrument/devices/counters_class.py
+++ b/src/instrument/devices/counters_class.py
@@ -237,7 +237,7 @@ class CountersClass:
     @property
     def _available_detectors(self):
         return oregistry.find_all("detector")
-    
+
     @property
     def detectors_channels(self):
         channels = {}
@@ -246,7 +246,7 @@ class CountersClass:
             # options.
             for option in getattr(det, "get_plotting_options", []):
                 channels[option] = det
-        
+
         return channels
 
     def select_plotting(self, selection):
@@ -256,5 +256,6 @@ class CountersClass:
                 self.detectors += [det]
             # det.select_plotting(item) selects that channel to plot.
             getattr(det, "select_plotting")(item)
+
 
 counters = CountersClass()

--- a/src/instrument/devices/counters_class.py
+++ b/src/instrument/devices/counters_class.py
@@ -304,7 +304,7 @@ class CountersClass:
             mon = 0
         else:
             _mon = self.detectors_plot_options[
-                self.detectors_plot_options == self.monitor
+                self.detectors_plot_options["channels"] == self.monitor
             ].index[0]
             while True:
                 mon = input(

--- a/src/instrument/devices/counters_class.py
+++ b/src/instrument/devices/counters_class.py
@@ -283,21 +283,14 @@ class CountersClass:
         dets = []
         for name, group in groups:
             det = oregistry.find(name)
-            print("\n", name, "\n", group)
             # det.select_plot(item) selects that channel to plot.
-            func = getattr(det, "select_plot")
-            print("0")
-            print(group["channels"].values)
-            func(group["channels"].values)
-            print("1")
+            getattr(det, "select_plot")(list(group["channels"].values))
             dets.append(det)
 
-        print("2")
         if self.default_scaler not in dets:
             dets.append(self.default_scaler)
             self.default_scaler.select_plot_channels([''])
 
-        print("2")
         self._dets = dets
 
     def plotselect(self):

--- a/src/instrument/devices/counters_class.py
+++ b/src/instrument/devices/counters_class.py
@@ -287,7 +287,7 @@ class CountersClass:
             getattr(det, "select_plot")(group["channels"].values)
             dets.append(det)
 
-        self.detectors = dets
+        self._dets = dets
 
     def plotselect(self):
         print("Options:")

--- a/src/instrument/devices/counters_class.py
+++ b/src/instrument/devices/counters_class.py
@@ -317,7 +317,7 @@ class CountersClass:
                     print("Please enter the index number only.")
                     continue
 
-                if mon > self.detectors_plot_options.size:
+                if mon >= self.detectors_plot_options.size:
                     print(f"Monitor index {mon} is invalid.")
                     continue
 

--- a/src/instrument/devices/counters_class.py
+++ b/src/instrument/devices/counters_class.py
@@ -243,9 +243,9 @@ class CountersClass:
     def detectors_plot_options(self):
         table = dict(detectors=[], channels=[])
         for det in self._available_detectors:
-            # det.get_plot_options will return a list of available
+            # det.plot_options will return a list of available
             # plotting options.
-            _options = getattr(det, "get_plot_options", [])
+            _options = getattr(det, "plot_options", [])
             table["channels"] += _options
             table["detectors"] += [det.name for _ in range(len(_options))]
 
@@ -261,10 +261,10 @@ class CountersClass:
                 self.detectors += [det]
             # det.select_plot(item) selects that channel to plot.
 
-            channel = self.detectors_plot_options.loc[ind]["channels"]
+            channels = self.detectors_plot_options.loc[ind]["channels"]
             # TODO: this may be unnecessary. Maybe we can use oregistry to get
             # the specific item from the name?
-            getattr(det, "select_plot")(channel)
+            getattr(det, "select_plot")(channels)
 
 
 counters = CountersClass()

--- a/src/instrument/devices/counters_class.py
+++ b/src/instrument/devices/counters_class.py
@@ -267,7 +267,7 @@ class CountersClass:
             getattr(det, "select_plot")(group["channels"].values)
 
     def plotselect(self):
-        print("Detectors options:")
+        print("Options:")
         print(self.detectors_plot_options)
 
         while True:

--- a/src/instrument/devices/scaler_4idCTR8.py
+++ b/src/instrument/devices/scaler_4idCTR8.py
@@ -199,6 +199,10 @@ class LocalScalerCH(ScalerCH):
 
         self._monitor = channel
 
+    def get_plot_options(self):
+        # Return all named scaler channels
+        return list(self.channels_name_map.keys())
+
 
 scaler_ctr8 = LocalScalerCH(
     '4idCTR8_1:scaler1', name='scaler_ctr8', labels=('detector', 'scaler')

--- a/src/instrument/devices/scaler_4idCTR8.py
+++ b/src/instrument/devices/scaler_4idCTR8.py
@@ -199,7 +199,8 @@ class LocalScalerCH(ScalerCH):
 
         self._monitor = channel
 
-    def get_plot_options(self):
+    @property
+    def plot_options(self):
         # Return all named scaler channels
         return list(self.channels_name_map.keys())
 

--- a/src/instrument/devices/scaler_4idCTR8.py
+++ b/src/instrument/devices/scaler_4idCTR8.py
@@ -204,6 +204,9 @@ class LocalScalerCH(ScalerCH):
         # Return all named scaler channels
         return list(self.channels_name_map.keys())
 
+    def select_plot(self, channels):
+        self.select_plot_channels(chan_names=channels)
+
 
 scaler_ctr8 = LocalScalerCH(
     '4idCTR8_1:scaler1', name='scaler_ctr8', labels=('detector', 'scaler')


### PR DESCRIPTION
Adds `plotselect` to the counters. It relies on gathering `oregistry` devices that are labeled `detector`. These devices must have two items: `plot_options` `property` that returns a list of components that can be plotted, and `select_plot` function that takes a list of names (a subset of `plot_options`) and makes those components `hinted`. 

I want to merge these changes to start testing during commissioning, but there are some potential improvements:
- Add an option for adding detectors that will just be read, but not plotted: right now if only `counters.plotselect()` is used, then if you're not plotting a given detector, it will not be read at all. `counters.extra_devices` already exist for this, but may want to add some option in `plotselect`?
- Ask about counting time? I added it to the counters initially to make it so that the user doesn't need to type the counting time in the scan, but this may be confusing. Remove it?
- Remember current plotting selection. It will remember for the monitor, but not the detector.