### PR TITLE
Tweak flag cameras default

### DIFF
--- a/src/instrument/devices/ad_vimba.py
+++ b/src/instrument/devices/ad_vimba.py
@@ -254,7 +254,7 @@ class VimbaDetector(Trigger, DetectorBase):
 
         self.setup_manual_trigger()
         self.save_images_off()
-        self.auto_save_on()
+        self.auto_save_off()
         self.plot_roi1()
 
     def plot_select(self, rois):


### PR DESCRIPTION
The flag cameras produce large data files, but the default was to save images. Now, the default will be to not save images (just ROIs). The simplest way to save images is to run `.auto_save_on()`, which will turn on image saving only during the scans.