### PR TITLE
Tweak setup_experiment to avoid the DM server if needed

### DIFF
--- a/src/instrument/utils/dm_utils.py
+++ b/src/instrument/utils/dm_utils.py
@@ -115,8 +115,12 @@ def get_esaf_users_badge(id):
 
 
 def get_current_run():
+    return bss_api.getCurrentRun()
+
+
+def get_current_run_name():
     try:
-        run = bss_api.getCurrentRun()
+        run = get_current_run()["name"]
     # This is needed in case the DM server is down.
     except DmException:
         print(

--- a/src/instrument/utils/dm_utils.py
+++ b/src/instrument/utils/dm_utils.py
@@ -8,7 +8,12 @@ from apstools.utils.aps_data_management import (
 )
 
 from dm import (
-    EsafApsDbApi, BssApsDbApi, ExperimentDsApi, UserDsApi, ObjectAlreadyExists
+    EsafApsDbApi,
+    BssApsDbApi,
+    ExperimentDsApi,
+    UserDsApi,
+    ObjectAlreadyExists,
+    DmException
 )
 from datetime import datetime
 from numpy import unique
@@ -110,7 +115,29 @@ def get_esaf_users_badge(id):
 
 
 def get_current_run():
-    return bss_api.getCurrentRun()
+    try:
+        run = bss_api.getCurrentRun()
+    # This is needed in case the DM server is down.
+    except DmException:
+        print(
+            "WARNING: could not reach the DM server, the run information may "
+            "be wrong!"
+        )
+        from datetime import datetime
+        now = datetime.now()
+        for i, date in zip(
+            (1, 2, 3),
+            (
+                datetime(now.year, 5, 1),
+                datetime(now.year, 9, 15),
+                datetime(now.year+1, 1, 1)
+            )
+        ):
+            if now < date:
+                run = f"{now.year}-{i}"
+                break
+
+    return run
 
 
 def dm_experiment_setup(

--- a/src/instrument/utils/experiment_setup.py
+++ b/src/instrument/utils/experiment_setup.py
@@ -27,7 +27,7 @@ from .dm_utils import (
     get_proposal_info,
     get_experiment,
     dm_experiment_setup,
-    get_current_run
+    get_current_run_name
 )
 from .run_engine import RE
 from ._logging_setup import logger
@@ -383,7 +383,7 @@ class ExperimentClass:
         else:
             self.base_experiment_path = (
                 SERVERS[self.server] /
-                get_current_run()["name"] /
+                get_current_run_name() /
                 self.experiment_name
             )
             # self.windows_base_experiment_path = (

--- a/src/instrument/utils/experiment_setup.py
+++ b/src/instrument/utils/experiment_setup.py
@@ -349,15 +349,21 @@ class ExperimentClass:
             sample_label: str = None,
             server: str = None,
             experiment_name: str = None,
-            reset_scan_id: int = None
+            reset_scan_id: int = None,
+            skip_DM: bool = False
     ):
-        # ESAF and proposal ID info first. Will get data from APS databases.
-        self.esaf_input(esaf_id)
-        self.proposal_input(proposal_id)
+        if skip_DM:
+            # ESAF and proposal ID info first. Will get data from APS databases.
+            self.esaf_input(esaf_id)
+            self.proposal_input(proposal_id)
 
-        # Selects where to save the data. Long term, this probably this will be
-        # mostly the DM.
-        self.server_input(server)
+            # Selects where to save the data. Long term, this probably this will
+            # be mostly the DM.
+            self.server_input(server)
+
+        else:
+            self.server = "dserv"
+
         # This is needed because if using the DM, the experiment name may need
         # to be changed.
         while True:


### PR DESCRIPTION
Added the `skip_DM` to avoid the DM server if it is down. The assumption here is that this will be rare, so this option will be really just used by an expert if really needed.

Close #54 